### PR TITLE
Add glmer engine for linear regression

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -7,6 +7,7 @@
   # This defines model functions in the parsnip model database
   make_stan_linear_reg()
   make_lme4_linear_reg()
+  make_glmer_linear_reg()
   make_gee_linear_reg()
   make_gee_logistic_reg()
   make_lme4_logistic_reg()

--- a/R/linear_reg_data.R
+++ b/R/linear_reg_data.R
@@ -183,6 +183,76 @@ make_lme4_linear_reg <- function() {
 
 # ------------------------------------------------------------------------------
 
+make_glmer_linear_reg <- function() {
+
+  parsnip::set_model_engine("linear_reg", "regression", "glmer")
+  parsnip::set_dependency("linear_reg", "glmer", "lme4", "regression")
+  parsnip::set_dependency("linear_reg", "glmer", "multilevelmod", "regression")
+
+  parsnip::set_encoding(
+    model = "linear_reg",
+    eng = "glmer",
+    mode = "regression",
+    options = list(
+      predictor_indicators = "none",
+      compute_intercept = FALSE,
+      remove_intercept = FALSE,
+      allow_sparse_x = FALSE
+    )
+  )
+
+  parsnip::set_fit(
+    model = "linear_reg",
+    eng = "glmer",
+    mode = "regression",
+    value = list(
+      interface = "formula",
+      protect = c("formula", "data", "weights"),
+      func = c(pkg = "lme4", fun = "glmer"),
+      defaults = list(family = rlang::expr(stats::gaussian))
+    )
+  )
+
+  parsnip::set_pred(
+    model = "linear_reg",
+    eng = "glmer",
+    mode = "regression",
+    type = "numeric",
+    value = list(
+      pre = reformat_lme_pred_data,
+      post =  NULL,
+      func = c(fun = "predict"),
+      args = list(
+        object = rlang::expr(object$fit),
+        newdata = rlang::expr(new_data),
+        allow.new.levels = TRUE,
+        re.form = NA,
+        na.action = rlang::expr(na.exclude),
+        type = "response"
+      )
+    )
+  )
+
+  parsnip::set_pred(
+    model = "linear_reg",
+    eng = "glmer",
+    mode = "regression",
+    type = "raw",
+    value = list(
+      pre = NULL,
+      post = NULL,
+      func = c(fun = "predict"),
+      args = list(
+        object = rlang::expr(object$fit),
+        newdata = rlang::expr(new_data)
+      )
+    )
+  )
+
+}
+
+# ------------------------------------------------------------------------------
+
 make_gee_linear_reg <- function() {
 
   parsnip::set_model_engine("linear_reg", "regression", "gee")

--- a/tests/testthat/test-linear-reg-glmer.R
+++ b/tests/testthat/test-linear-reg-glmer.R
@@ -1,0 +1,48 @@
+
+test_that('glmer execution', {
+  skip_if_not_installed("lme4")
+  skip_on_cran()
+
+  glmer_cl <- call2("glmer", .ns = "lme4", f, data = expr(riesby_tr), family = gaussian(make.link("identity")))
+
+  set.seed(2452)
+  glmer_mod <- eval_tidy(glmer_cl)
+
+  set.seed(2452)
+  expect_error(
+    ps_mod <-
+      linear_reg() %>%
+      set_engine("glmer", family = gaussian(make.link("identity"))) %>%
+      fit(f, data = riesby_tr),
+    regex = NA
+  )
+
+  expect_equal(
+    coef(ps_mod$fit)$subject,
+    coef(glmer_mod)$subject
+  )
+
+  glmer_pred <- predict(glmer_mod, riesby_te, allow.new.levels = TRUE)
+
+  ps_pred <- predict(ps_mod, riesby_te)
+
+  expect_equal(unname(glmer_pred), ps_pred$.pred)
+
+})
+
+
+test_that('mode specific package dependencies', {
+  expect_identical(
+    get_from_env(paste0("linear_reg", "_pkgs")) %>%
+      dplyr::filter(engine == "glmer", mode == "classification") %>%
+      dplyr::pull(pkg),
+    list()
+  )
+
+  expect_identical(
+    get_from_env(paste0("linear_reg", "_pkgs")) %>%
+      dplyr::filter(engine == "glmer", mode == "regression") %>%
+      dplyr::pull(pkg),
+    list(c("lme4", "multilevelmod"))
+  )
+})


### PR DESCRIPTION
The `glmer` engine was available only for logistic regression, this PR adds it as an engine for `linear_reg()`.
I tried to follow the code already present for the `lmer` engine as an example.